### PR TITLE
Moved register collection check out of config. This way you can load

### DIFF
--- a/application/__init__.py
+++ b/application/__init__.py
@@ -6,8 +6,16 @@ from flask import Flask
 app = Flask(__name__)
 app.config.from_object(os.environ.get('SETTINGS'))
 
+
+# we'll use this handle to db to check collections
+# this app can serve.
+import pymongo
+client = pymongo.MongoClient(app.config['MONGO_URI'])
+db = client.get_default_database()
+
 from application.views import *  # NOQA
 
 if not app.debug:
     app.logger.addHandler(logging.StreamHandler())
     app.logger.setLevel(logging.INFO)
+

--- a/application/views.py
+++ b/application/views.py
@@ -10,7 +10,7 @@ from flask import (
     current_app
 )
 
-from application import app
+from application import app, db
 from .registry import registers, Register
 from thingstance.representations import representations as _representations
 
@@ -132,10 +132,9 @@ def find_things(tag, query={}, suffix="html"):
 
 
 def find_or_initalise_register(register_name):
-    #TODO have another look at this
-    if register_name not in current_app.config['REGISTERS']:
-        return abort(404)
-    register = registers.get(register_name)
-    if not register:
+    if not registers.get(register_name):
+        collections = db.collection_names()
+        if register_name not in collections:
+            return abort(404)
         registers[register_name] = Register(register_name, current_app.config['MONGO_URI'])
     return registers.get(register_name)

--- a/config/config.py
+++ b/config/config.py
@@ -6,7 +6,6 @@ class Config(object):
     MONGO_URI = os.environ.get('MONGOLAB_URI', 'mongodb://127.0.0.1:27017/thingstance')
     PAGE_SIZE = int(os.environ['PAGE_SIZE'])
     SECRET_KEY = os.environ['SECRET_KEY']
-    REGISTERS = os.environ['REGISTERS'].split(',')
 
 class DevelopmentConfig(Config):
     DEBUG = True

--- a/environment.sh
+++ b/environment.sh
@@ -6,5 +6,3 @@ export PAGE_SIZE=50
 export PORT=8000
 export SECRET_KEY='not-secret'
 export HEROKU_KEY=`heroku auth:token`
-# in local dev multiple registers in same app
-export REGISTERS='register,field,datatype'


### PR DESCRIPTION
another register and don't need to restart app. App config and what's
is not duplicated and can't be out of sync.