### PR TITLE
Hide sort/filter controls for paginated datasets.

### DIFF
--- a/application/templates/meta.html
+++ b/application/templates/meta.html
@@ -1,9 +1,10 @@
 <div class="meta">
-<span id="visible-records">Total entries: {{meta.total}}. Page {{ meta.page}}</span> of <span id="total">{{ meta.pages}}</span>
-    {% if meta.page > 1 %}
-        <a href="{{url_for('things', page=meta.page-1)}}">back</a>
-    {% endif %}
-    {% if meta.page < meta.pages %}
-        <a href="{{url_for('things', page=meta.page+1)}}">next</a>
-    {% endif %}
+Showing <span id="visible-records">{{meta.total}}</span> of {{meta.total}} entries.
+Page {{ meta.page}} of <span id="total">{{ meta.pages}}</span>
+	{% if meta.page > 1 %}
+	  <a href="{{url_for('things', page=meta.page-1)}}">back</a>
+	{% endif %}
+	{% if meta.page < meta.pages %}
+	  <a href="{{url_for('things', page=meta.page+1)}}">next</a>
+	{% endif %}
 </div>

--- a/application/templates/things.html
+++ b/application/templates/things.html
@@ -26,10 +26,12 @@
 
         <div class="panel thing" id="entries">
 
+        {% if meta.pages == 1 %}
         <div class="search">
           Filter entries:
           <input id="search-input" placeholder="search" />
         </div>
+        {% endif %}
 
         <div id="table-outer">
 
@@ -38,7 +40,11 @@
             <thead>
               <tr>
               {% for key in thing_keys %}
-                <th>{{ key | datatype("field")}} <span class="sort" data-sort="{{ key }}">sort</span></td>
+                <th>{{ key | datatype("field")}}
+                  {% if meta.pages == 1 %}
+                  <span class="sort" data-sort="{{ key }}">sort</span>
+                  {% endif %}
+                </th>
               {% endfor %}
               </tr>
               </tr>


### PR DESCRIPTION
If our dataset only has one page, show sort/filter controls.
Otherwise, hide them.

This is because the sort/filter controls are entirely
client-side, so they don't work on paginated datasets.

Also update the "Showing X of Y entries" HTML, which 
updates when the user filters the entries. 