### PR TITLE
Comma-separate large numbers.

### DIFF
--- a/application/templates/meta.html
+++ b/application/templates/meta.html
@@ -1,10 +1,15 @@
 <div class="meta">
-Showing <span id="visible-records">{{meta.total}}</span> of {{meta.total}} entries.
-Page {{ meta.page}} of <span id="total">{{ meta.pages}}</span>
-	{% if meta.page > 1 %}
-	  <a href="{{url_for('things', page=meta.page-1)}}">back</a>
-	{% endif %}
-	{% if meta.page < meta.pages %}
-	  <a href="{{url_for('things', page=meta.page+1)}}">next</a>
-	{% endif %}
+Showing <span id="visible-records">{{ meta.total | thousands_comma }}</span>
+of {{ meta.total | thousands_comma }} entries.
+
+Page {{ meta.page | thousands_comma }}
+of <span id="total">{{ meta.pages | thousands_comma }}</span>
+
+{% if meta.page > 1 %}
+  <a href="{{url_for('things', page=meta.page-1)}}">back</a>
+{% endif %}
+{% if meta.page < meta.pages %}
+  <a href="{{url_for('things', page=meta.page+1)}}">next</a>
+{% endif %}
+
 </div>

--- a/application/templates/things.html
+++ b/application/templates/things.html
@@ -16,7 +16,7 @@
           </div>
 
           <div class="medium-3 small-12 columns metadata">
-            <span class="big-number">{{ meta.total }}</span>
+            <span class="big-number">{{ meta.total | thousands_comma }}</span>
             <h4 class="subheader"><small>Total entries</small></h4>
           </div>
 
@@ -101,7 +101,7 @@
     var itemList = new List('entries', options);
     itemList.on('updated', function() {
       var s = document.getElementById('visible-records');
-      s.innerHTML = itemList.visibleItems.length;
+      s.innerHTML = itemList.visibleItems.length.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     });
 
   })();

--- a/application/views.py
+++ b/application/views.py
@@ -45,6 +45,13 @@ def datatype_filter(value, fieldname):
     return value
 
 
+@app.template_filter('thousands_comma')
+def thousands_comma_filter(value):
+    if value:
+        return "{:,d}".format(value)
+    return value
+
+
 # TBD: push this into thingstance.representations ..
 representations = {}
 for representation in _representations:


### PR DESCRIPTION
Use custom template filter to do this, since it doesn't seem
to be possible to use the `{:,d}` formatter directly in the
Jinja template.